### PR TITLE
Handle missing shows gracefully in metrics generation

### DIFF
--- a/src/trakt_data/metrics.py
+++ b/src/trakt_data/metrics.py
@@ -747,7 +747,13 @@ def _generate_up_next_show_metrics(
     hidden_show_trakt_ids: set[int],
     completed_episodes: set[tuple[int, int, int]],
 ) -> None:
-    show = _export_media_show(ctx, trakt_id=trakt_show_id)
+    try:
+        show = _export_media_show(ctx, trakt_id=trakt_show_id)
+    except requests.HTTPError as exc:
+        if exc.response is not None and exc.response.status_code == 404:
+            logger.error("Show not found: %s", trakt_show_id)
+            return
+        raise
     trakt_show_slug = show["ids"]["slug"]
     show_hidden_str = "true" if trakt_show_id in hidden_show_trakt_ids else "false"
 


### PR DESCRIPTION
## Summary
- catch 404 errors while generating per-show metrics and skip missing shows
- keep show export function's API unchanged so callers handle errors

## Testing
- `uv run ruff check .`
- `uv run mypy src/trakt_data`


------
https://chatgpt.com/codex/tasks/task_e_68b9bddd5e888326808a58ac640bcfa3