### PR TITLE
Reduce INFO logging for API requests and pruning

### DIFF
--- a/src/trakt_data/cache.py
+++ b/src/trakt_data/cache.py
@@ -116,6 +116,6 @@ def prune_cache_dir(
     for idx in expired_indices:
         file, mtime, age = files[idx]
         age_dt = timedelta(seconds=int(age))
-        logger.info("Prune '%s' (%s, %s)", file, mtime, age_dt)
+        logger.debug("Prune '%s' (%s, %s)", file, mtime, age_dt)
         if not dry_run:
             file.unlink()

--- a/src/trakt_data/trakt.py
+++ b/src/trakt_data/trakt.py
@@ -391,7 +391,7 @@ def trakt_api_get(
     if not path.startswith("/"):
         path = f"/{path}"
 
-    logger.info("GET %s", f"https://api.trakt.tv{path}")
+    logger.debug("GET %s", f"https://api.trakt.tv{path}")
     response = session.get(f"https://api.trakt.tv{path}", params=params)
     response.raise_for_status()
 
@@ -420,7 +420,7 @@ def trakt_api_paginated_get(
         params["page"] = str(page)
         params["limit"] = str(limit)
 
-        logger.info("GET %s", f"https://api.trakt.tv{path}")
+        logger.debug("GET %s", f"https://api.trakt.tv{path}")
         response = session.get(f"https://api.trakt.tv{path}", params=params)
         response.raise_for_status()
 


### PR DESCRIPTION
## Summary
- Reduce verbosity by logging cache file pruning at debug level
- Lower HTTP GET request logs to debug to avoid excessive INFO messages

## Testing
- `uv run ruff check .`
- `uv run mypy .`
- `uv run --with pytest pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9d7b470d08326931200251b546fc3