### PR TITLE
Refine logging levels for missing content and 404s

### DIFF
--- a/src/trakt_data/export.py
+++ b/src/trakt_data/export.py
@@ -274,7 +274,7 @@ def _export_shows_watched_progress(ctx: Context) -> None:
             data = trakt_api_get(ctx.session, path=path)
         except requests.HTTPError as exc:
             if exc.response is not None and exc.response.status_code == 404:
-                logger.error("Show progress not found: %s", show_id)
+                logger.warning("Show progress not found: %s", show_id)
                 continue
             raise
         show_progress = {

--- a/src/trakt_data/metrics.py
+++ b/src/trakt_data/metrics.py
@@ -237,7 +237,7 @@ def _resolve_season_trakt_id(
             break
 
     if season_trakt_id is None:
-        logger.warning(
+        logger.error(
             "'%s' missing S%d",
             show["title"],
             season_number,
@@ -276,7 +276,7 @@ def _resolve_episode_trakt_id(
 
     if episode_trakt_id is None:
         show = _export_media_show(ctx, show_trakt_id)
-        logger.warning(
+        logger.error(
             "'%s' missing S%dE%d",
             show["title"],
             season_number,
@@ -751,7 +751,7 @@ def _generate_up_next_show_metrics(
         show = _export_media_show(ctx, trakt_id=trakt_show_id)
     except requests.HTTPError as exc:
         if exc.response is not None and exc.response.status_code == 404:
-            logger.error("Show not found: %s", trakt_show_id)
+            logger.warning("Show not found: %s", trakt_show_id)
             return
         raise
     trakt_show_slug = show["ids"]["slug"]


### PR DESCRIPTION
## Summary
- promote missing season/episode lookups to error level
- demote show-not-found cases to warnings

## Testing
- `uv run ruff check .`
- `uv run mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68b9dbe78b108326be18c37d50823a24