### PR TITLE
Use paginated API calls for watched and ratings endpoints

### DIFF
--- a/src/trakt_data/export.py
+++ b/src/trakt_data/export.py
@@ -145,7 +145,7 @@ def _export_watched(
     output_path = ctx.output_dir / "watched" / f"watched-{type}.json"
     if _excluded(ctx, output_path) or _fresh(ctx, output_path):
         return
-    data = trakt_api_get(ctx.session, path=f"/sync/watched/{type}")
+    data = trakt_api_paginated_get(ctx.session, path=f"/sync/watched/{type}")
     write_json(output_path, data)
 
 
@@ -251,7 +251,7 @@ def _export_ratings(
     output_path = ctx.output_dir / "ratings" / f"ratings-{type}.json"
     if _excluded(ctx, output_path) or _fresh(ctx, output_path):
         return
-    data = trakt_api_get(ctx.session, path=f"/sync/ratings/{type}")
+    data = trakt_api_paginated_get(ctx.session, path=f"/sync/ratings/{type}")
     write_json(output_path, data)
 
 


### PR DESCRIPTION
## Summary
Updated the watched and ratings export functions to use paginated API calls instead of standard API calls, ensuring all data is retrieved when results span multiple pages.

## Key Changes
- Changed `_export_watched()` to use `trakt_api_paginated_get()` instead of `trakt_api_get()` for the `/sync/watched/{type}` endpoint
- Changed `_export_ratings()` to use `trakt_api_paginated_get()` instead of `trakt_api_get()` for the `/sync/ratings/{type}` endpoint

## Details
The Trakt API may return paginated results for these endpoints when users have large libraries. Using the paginated variant ensures that all watched items and ratings are exported, not just the first page of results.

https://claude.ai/code/session_01QgNKkBf2bLXA58iR4uQJKK