### PR TITLE
Request page limit of 250 to match Trakt's cap

### DIFF
--- a/src/trakt_data/trakt.py
+++ b/src/trakt_data/trakt.py
@@ -414,7 +414,7 @@ def trakt_api_paginated_get(
     results: list[Any] = []
 
     page = 1
-    limit = 1000
+    limit = 250
     page_count = 1
     item_count = 0
 


### PR DESCRIPTION
Trakt lowered the maximum page size for paginated endpoints to 250 and clamps larger requests, so asking for 1000 logged a spurious 'expected limit 1000, got 250' warning on every page. Request 250 directly to match the server cap and silence the noise.


Claude-Session: https://claude.ai/code/session_01QgNKkBf2bLXA58iR4uQJKK