### PR TITLE
Fix Trakt token refresh workflow

### DIFF
--- a/.github/workflows/trakt.yml
+++ b/.github/workflows/trakt.yml
@@ -13,18 +13,28 @@ jobs:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ vars.GH_APP_ID }}
+          client-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Refresh Trakt token
         run: |
-          curl --silent --fail \
-              -X POST \
-              -F "client_id=$TRAKT_CLIENT_ID" \
-              -F "client_secret=$TRAKT_CLIENT_SECRET" \
-              -F "refresh_token=$TRAKT_REFRESH_TOKEN" \
-              -F "grant_type=refresh_token" \
-            'https://api.trakt.tv/oauth/token' >token.json
+          set -o pipefail
+
+          jq --null-input \
+              --arg client_id "$TRAKT_CLIENT_ID" \
+              --arg client_secret "$TRAKT_CLIENT_SECRET" \
+              --arg refresh_token "$TRAKT_REFRESH_TOKEN" \
+              '{
+                client_id: $client_id,
+                client_secret: $client_secret,
+                refresh_token: $refresh_token,
+                grant_type: "refresh_token"
+              }' \
+            | curl --silent --show-error --fail-with-body \
+                -X POST \
+                -H 'Content-Type: application/json' \
+                --data-binary @- \
+                'https://api.trakt.tv/oauth/token' >token.json
         env:
           TRAKT_CLIENT_ID: ${{ secrets.TRAKT_CLIENT_ID }}
           TRAKT_CLIENT_SECRET: ${{ secrets.TRAKT_CLIENT_SECRET }}


### PR DESCRIPTION
### Motivation
- Remove the deprecated `app-id` input for the `actions/create-github-app-token` step to eliminate workflow warnings. 
- Ensure the Trakt OAuth refresh request is formatted as JSON because the API expects a JSON body rather than multipart form fields. 
- Make the job fail noisily and provide useful API error details in CI when the token refresh fails.

### Description
- Replace the `app-id` input with the non-deprecated `client-id` for `actions/create-github-app-token` in `.github/workflows/trakt.yml`. 
- Switch the token refresh request to emit a JSON payload via `jq --null-input` and pipe it to `curl` with `-H 'Content-Type: application/json'` and `--data-binary @-`. 
- Add `set -o pipefail` and use `curl --show-error --fail-with-body` so HTTP failures return visible error bodies instead of only an `exit code 22`.

### Testing
- Ran `uv run ruff check .` and it completed successfully. 
- Ran `uv run mypy .` and it completed successfully. 
- Ran `git diff --check` and there were no whitespace or diff issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58369cd7448326852355007d5249ce)